### PR TITLE
Partial fix for #18

### DIFF
--- a/browser-sync-src/stylesheet-sync.js
+++ b/browser-sync-src/stylesheet-sync.js
@@ -58,8 +58,8 @@ exports.updateStylesheet = function (bs, data) {
     var parent = stylesheetElem.parentElement;
 
     var replacement = document.createElement('style');
-    replacement.dataset.originalHref = stylesheetElem.getAttribute('href') || stylesheetElem.dataset.originalHref;
-    replacement.innerText = data.content;
+    replacement.dataset.originalHref = stylesheetElem.href || stylesheetElem.dataset.originalHref;
+    replacement.textContent = data.content;
 
     parent.replaceChild(replacement, stylesheetElem);
   }

--- a/lib/browser-sync.js
+++ b/lib/browser-sync.js
@@ -1373,10 +1373,11 @@ exports.updateStylesheet = function (bs, data) {
     var parent = stylesheetElem.parentElement;
 
     var replacement = document.createElement('style');
-    replacement.dataset.originalHref = stylesheetElem.getAttribute('href') || stylesheetElem.dataset.originalHref;
-    replacement.innerText = data.content;
+    replacement.dataset.originalHref = stylesheetElem.href || stylesheetElem.dataset.originalHref;
+    replacement.textContent = data.content;
 
     parent.replaceChild(replacement, stylesheetElem);
   }
 };
+
 },{"./browser.utils":2,"./events":6}]},{},[15]);


### PR DESCRIPTION
Relative spreadsheet URLs are now handled correctly.

Additionally, using textContent instead of innerText (innerText caused `<br>`s to appear inside `<style>`s).
