### PR TITLE
Replacing use of GA event 'value' with 'label'

### DIFF
--- a/lib/edl.js
+++ b/lib/edl.js
@@ -107,17 +107,15 @@ Settings.ready()
 //Send status to Google Analytics every 1min
 setInterval(() => {
   GoogleAnalytics.trackEvent({
-    category: 'EDL tab',
-    action: 'Status',
-    label: 'Number of devices',
-    value: deviceList.getAll().length
+    category: 'EDL tab status',
+    action: 'Number of devices',
+    label: (deviceList.getAll().length).toString()
   });
 
   GoogleAnalytics.trackEvent({
-    category: 'EDL tab',
-    action: 'Status',
-    label: 'Zoom level',
-    value: (zoomWidget.getValue() * 100)
+    category: 'EDL tab status',
+    action: 'Zoom level',
+    label: zoomWidget.getValue().toString()
   });
 }, 60000);
 
@@ -139,8 +137,7 @@ function initOptions() {
 
     GoogleAnalytics.trackEvent({
       category: 'EDL tab',
-      action: 'Toggle artwork',
-      value: ~~state
+      action: 'Artwork ' + (state ? 'on' : 'off')
     });
 
     Settings.setValue('show-device-artwork', state);


### PR DESCRIPTION
I played with results from the previous GA setup a bit and it turns out that event 'value' is rather hard to work with. It's impossible to see the distribution of values, you get only sum and average. So, I changed the setup to use labels instead:

| Category | Action | Label | Value | Description |
| --- | --- | --- | --- | --- |
| EDL tab | Spawn device | _device name_ | - | User spawns a new device |
| EDL tab | Create device | _device name + (width x height)_ | - | User creates a custom device |
| EDL tab | Artwork on | - | - | User turns on device artwork |
| EDL tab | Artwork off | - | - | User turns off device artwork |
| EDL tab status | Number of devices | _# of active devices_ | - | Event sent every minute with number of currently active devices |
| EDL tab status | Zoom level | _level_ | - | Event sent every minute with current zoom level (value between 0.1 and 1) |

That way, we will get this kind of output:

![screen shot 2015-03-18 at 21 34 10](https://cloud.githubusercontent.com/assets/985504/6718793/991123d6-cdb6-11e4-9939-df5ca71fe0ea.png)

Instead of something like this:

![screen shot 2015-03-18 at 21 36 26](https://cloud.githubusercontent.com/assets/985504/6718829/e38bf828-cdb6-11e4-81a8-538984f9adbe.png)
