### PR TITLE
RDP API changes

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -100,13 +100,13 @@ class Device {
       .connect()
       .then(callCommand("Network.enable"))
       .then(callCommand("Page.enable"))
-      .then(callCommand("Page.setTouchEmulationEnabled", {
+      .then(callCommand("Emulation.setTouchEmulationEnabled", {
         enabled: winCtrl._touch
       }))
       .then(callCommand("Network.setUserAgentOverride", {
         userAgent: winCtrl._userAgent
       }))
-      .then(callCommand("Page.setDeviceMetricsOverride", {
+      .then(callCommand("Emulation.setDeviceMetricsOverride", {
         width: winCtrl._width,
         height: winCtrl._height,
         deviceScaleFactor: winCtrl._deviceScaleFactor,


### PR DESCRIPTION
Update RDP calls (`Page.setTouchEmulationEnabled` -> `Emulation.setTouchEmulationEnabled`, `Page.setDeviceMetricsOverride` -> `Emulation.setDeviceMetricsOverride`). Tested in Chrome 45. Closes #35 
